### PR TITLE
[MOD] modified deterministic trace to inject CF5 failures into mrubis;

### DIFF
--- a/code/mRUBiS/mRUBiS_CompArch_Simulator/src/de/mdelab/morisia/comparch/simulator/impl/Trace_Deterministic.java
+++ b/code/mRUBiS/mRUBiS_CompArch_Simulator/src/de/mdelab/morisia/comparch/simulator/impl/Trace_Deterministic.java
@@ -48,7 +48,7 @@ public class Trace_Deterministic implements InjectionStrategy {
 				
 				injections.add(new Injection<Component>(IssueType.CF1, this
 						.getComponent(2, 11)));
-				injections.add(new Injection<Component>(IssueType.CF1, this
+				injections.add(new Injection<Component>(IssueType.CF5, this
 						.getComponent(5, 13)));
 				injections.add(new Injection<Component>(IssueType.CF3, this
 						.getComponent(7, 15)));
@@ -140,7 +140,7 @@ public class Trace_Deterministic implements InjectionStrategy {
 				} else if (runCount%10 == 5) {
 					System.out.print("\n 5");
 				
-						injections.add(new Injection<Component>(IssueType.CF1, this
+						injections.add(new Injection<Component>(IssueType.CF5, this
 						.getComponent(8, 9)));
 					Component component = this.getComponent(1, 6);
 					injections.add(new Injection<ProvidedInterface>(IssueType.CF2,
@@ -160,16 +160,14 @@ public class Trace_Deterministic implements InjectionStrategy {
 			
 		} else if (runCount%10 == 7) {
 			System.out.print("\n 7");
-			injections.add(new Injection<Component>(IssueType.CF3, this
+			injections.add(new Injection<Component>(IssueType.CF5, this
 					.getComponent(2, 10)));
-				injections.add(new Injection<Component>(IssueType.CF3, this
+				injections.add(new Injection<Component>(IssueType.CF5, this
 						.getComponent(6, 14)));
-				injections.add(new Injection<Component>(IssueType.CF1, this
+				injections.add(new Injection<Component>(IssueType.CF5, this
 						.getComponent(5, 3)));
-				injections.add(new Injection<Component>(IssueType.CF3, this
+				injections.add(new Injection<Component>(IssueType.CF5, this
 						.getComponent(9, 7)));
-				injections.add(new Injection<ProvidedInterface>(IssueType.CF2, this
-						.getComponent(8, 7).getProvidedInterfaces().get(0)));
 			
 			} else if (runCount%10 == 8) {
 				System.out.print("\n 8");
@@ -188,7 +186,7 @@ public class Trace_Deterministic implements InjectionStrategy {
 				injections.add(new Injection<ProvidedInterface>(IssueType.CF2, this
 						.findMostCriticalComponent(5).getProvidedInterfaces()
 						.get(0)));
-				injections.add(new Injection<Component>(IssueType.CF3, this
+				injections.add(new Injection<Component>(IssueType.CF5, this
 						.findLeastCriticalComponent(2)));
 			
 			}  


### PR DESCRIPTION
As discussed on Tuesday, I modified the java class "Trace_Deterministic" to inject CF5 failures.

OLD failure injection matrix:

Shop # | MOD 10 = 0 | MOD 10 = 1 | MOD 10 = 2 | MOD 10 = 3 | MOD 10 = 4 | MOD 10 = 5 | MOD 10 = 6 | MOD 10 = 7 | MOD 10 = 8 | MOD 10 = 9
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
0 | CF1 | CF3 | - | - | CF1 | - | - | - | - | -
1 | - | - | CF3 | CF2 | CF1 | CF2 | - | - | - | -
2 | CF1 | - | - | CF2 | CF1 | - | - | CF3 | - | CF2
3 | - | CF3 | - | CF2 | CF1 | - | - | - | - | -
4 | - | CF3 | CF1 | - | CF1 | - | CF1 | - | - | -
5 | CF1 | CF3 | - | - | CF1 | - | CF2 | CF1 | CF2 | CF3
6 | - | CF3 | CF2 | - | CF1 | - | CF3 | CF3 | CF1 | -
7 | CF3 | CF3 | CF2 | CF2 | - | - | - | - | - | CF2
8 | CF2 | - | - | CF2 | CF1 | CF1 | - | CF2 | - | CF3
9 | CF3 | CF3 | CF1 | - | CF1 | - | - | CF3 | - | -

UPDATED failure injection matrix:

Shop # | MOD 10 = 0 | MOD 10 = 1 | MOD 10 = 2 | MOD 10 = 3 | MOD 10 = 4 | MOD 10 = 5 | MOD 10 = 6 | MOD 10 = 7 | MOD 10 = 8 | MOD 10 = 9
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
0 | CF1 | CF3 | - | - | CF1 | - | - | - | - | -
1 | - | - | CF3 | CF2 | CF1 | CF2 | - | - | - | -
2 | CF1 | - | - | CF2 | CF1 | - | - | CF5 | - | CF1
3 | - | CF3 | - | CF2 | CF1 | - | - | - | - | -
4 | - | CF3 | CF1 | - | CF1 | - | CF1 | - | - | -
5 | CF5 | CF3 | - | - | CF1 | - | CF2 | CF5 | CF2 | CF2
6 | - | CF3 | CF2 | - | CF1 | - | CF3 | CF5 | CF1 | -
7 | CF3 | CF3 | CF2 | CF2 | - | - | - | - | - | CF3
8 | CF2 | - | - | CF2 | CF1 | CF5 | - |   | - | CF2
9 | CF3 | CF3 | CF1 | - | CF1 | - | - | CF5 | - | -